### PR TITLE
feat(ci): add platforms

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,4 +20,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: qonto/qonto-mcp-server:latest


### PR DESCRIPTION
Adding `linux/amd64,linux/arm64` so that the Docker image is built for multiple platforms (e.g. including MacOS with ARM architecture).