### PR TITLE
feat(transactions): add pagination and filtering support to get_qonto_transactions

### DIFF
--- a/qonto_mcp/tools/transactions/transactions.py
+++ b/qonto_mcp/tools/transactions/transactions.py
@@ -5,14 +5,53 @@ from qonto_mcp import mcp
 
 
 @mcp.tool()
-def get_qonto_transactions(bank_account_id: str):
+def get_qonto_transactions(
+    bank_account_id: str,
+    page: Optional[int] = None,
+    per_page: Optional[int] = None,
+    settled_at_from: Optional[str] = None,
+    settled_at_to: Optional[str] = None,
+    status: Optional[str] = None,
+    side: Optional[str] = None,
+    sort_by: Optional[str] = None,
+):
     """
     Retrieves transactions from the Qonto API for a specific bank account.
 
-    Example: get_qonto_transactions(bank_account_id='0193f298-d9f3-7b77-8566-ce356449d7f3')
+    Args:
+        bank_account_id: UUID of the bank account
+        page: Page number for pagination (default: 1)
+        per_page: Number of transactions per page (max: 100)
+        settled_at_from: Filter transactions settled after this date (ISO 8601)
+        settled_at_to: Filter transactions settled before this date (ISO 8601)
+        status: Filter by status (pending, completed, declined)
+        side: Filter by side (credit, debit)
+        sort_by: Sort order (settled_at:asc, settled_at:desc, updated_at:asc, updated_at:desc)
+
+    Example: get_qonto_transactions(
+                bank_account_id='0193f298-d9f3-7b77-8566-ce356449d7f3',
+                settled_at_from='2025-01-01T00:00:00Z',
+                settled_at_to='2025-12-31T23:59:59Z',
+                page=1
+             )
     """
     url = f"{qonto_mcp.thirdparty_host}/v2/transactions"
     params = {"bank_account_id": bank_account_id}
+
+    if page is not None:
+        params["page"] = page
+    if per_page is not None:
+        params["per_page"] = per_page
+    if settled_at_from is not None:
+        params["settled_at_from"] = settled_at_from
+    if settled_at_to is not None:
+        params["settled_at_to"] = settled_at_to
+    if status is not None:
+        params["status"] = status
+    if side is not None:
+        params["side"] = side
+    if sort_by is not None:
+        params["sort_by"] = sort_by
 
     try:
         response = requests.get(url, headers=qonto_mcp.headers, params=params)
@@ -53,3 +92,77 @@ def get_qonto_transaction(transaction_id: str, includes: list = None):
         return response.json()
     except Exception as e:
         return f"Error fetching transaction: {str(e)}"
+
+
+@mcp.tool()
+def get_all_qonto_transactions(
+    bank_account_id: str,
+    settled_at_from: Optional[str] = None,
+    settled_at_to: Optional[str] = None,
+    status: Optional[str] = None,
+    side: Optional[str] = None,
+    sort_by: Optional[str] = None,
+) -> dict:
+    """
+    Fetches ALL transactions by iterating through all pages.
+
+    Args:
+        bank_account_id: UUID of the bank account
+        settled_at_from: Filter transactions settled after this date (ISO 8601)
+        settled_at_to: Filter transactions settled before this date (ISO 8601)
+        status: Filter by status (pending, completed, declined)
+        side: Filter by side (credit, debit)
+        sort_by: Sort order (settled_at:asc, settled_at:desc, updated_at:asc, updated_at:desc)
+
+    Returns:
+        Dict with transactions list and metadata.
+
+    Example: get_all_qonto_transactions(
+                bank_account_id='0193f298-d9f3-7b77-8566-ce356449d7f3',
+                settled_at_from='2025-01-01T00:00:00Z',
+                settled_at_to='2025-12-31T23:59:59Z'
+             )
+    """
+    all_transactions = []
+    page = 1
+    total_pages = 1
+
+    try:
+        while page <= total_pages:
+            result = get_qonto_transactions(
+                bank_account_id=bank_account_id,
+                page=page,
+                per_page=100,
+                settled_at_from=settled_at_from,
+                settled_at_to=settled_at_to,
+                status=status,
+                side=side,
+                sort_by=sort_by,
+            )
+
+            if isinstance(result, str):
+                return {
+                    "error": result,
+                    "transactions": all_transactions,
+                    "meta": {"pages_fetched": page - 1, "total_count": len(all_transactions)}
+                }
+
+            transactions = result.get("transactions", [])
+            all_transactions.extend(transactions)
+
+            meta = result.get("meta", {})
+            total_pages = meta.get("total_pages", 1)
+
+            page += 1
+
+    except Exception as e:
+        return {
+            "error": str(e),
+            "transactions": all_transactions,
+            "meta": {"pages_fetched": page - 1, "total_count": len(all_transactions)}
+        }
+
+    return {
+        "transactions": all_transactions,
+        "meta": {"pages_fetched": page - 1, "total_count": len(all_transactions)}
+    }


### PR DESCRIPTION
## Summary

The current `get_qonto_transactions` tool only returns the first page of results (100 transactions max), making it impossible to access the full transaction history for accounts with more data.

This PR adds:
- **Pagination parameters** (`page`, `per_page`) to `get_qonto_transactions`
- **Date filtering** (`settled_at_from`, `settled_at_to`) for time-range queries
- **Status/side filtering** to narrow down results
- **Sorting options** (`sort_by`) for flexible ordering
- **New `get_all_qonto_transactions` helper** that automatically fetches all pages

## Problem

When calling `get_qonto_transactions`, the API returns pagination metadata showing there's more data:

```json
{
  "meta": {
    "total_pages": 9,
    "total_count": 894,
    "current_page": 1,
    "per_page": 100
  }
}
```

But there was no way to access pages 2-9.

## Solution

### Enhanced `get_qonto_transactions`

```python
get_qonto_transactions(
    bank_account_id='...',
    page=2,                              # pagination
    per_page=50,                         # results per page
    settled_at_from='2025-01-01T00:00:00Z',  # date filters
    settled_at_to='2025-12-31T23:59:59Z',
    status='completed',                  # status filter
    side='debit',                        # credit/debit filter
    sort_by='settled_at:desc'            # sorting
)
```

### New `get_all_qonto_transactions` helper

Automatically iterates through all pages:

```python
get_all_qonto_transactions(
    bank_account_id='...',
    settled_at_from='2025-01-01T00:00:00Z',
    settled_at_to='2025-12-31T23:59:59Z'
)
# Returns: {"transactions": [...], "meta": {"pages_fetched": 6, "total_count": 580}}
```

## Testing

Verified with a real account containing 894 transactions across 9 pages:

| Test | Result |
|------|--------|
| `get_qonto_transactions(page=1, per_page=10)` | ✅ 10 transactions returned |
| `get_qonto_transactions(page=6)` | ✅ Page 6 data returned |
| `get_all_qonto_transactions(2025 filter)` | ✅ 580 transactions, 6 pages fetched |

## API Reference

Parameters align with [Qonto API documentation](https://api-doc.qonto.com/) for `GET /v2/transactions`:
- `page` (int): Page number (default: 1)
- `per_page` (int): Results per page (max: 100)
- `settled_at_from` / `settled_at_to` (str): ISO 8601 date filters
- `status` (str): pending, completed, declined
- `side` (str): credit, debit
- `sort_by` (str): settled_at:asc, settled_at:desc, updated_at:asc, updated_at:desc

## Checklist

- [x] Follows existing code style (`Optional[X]` type hints)
- [x] Docstrings updated with examples
- [x] Error handling consistent with other tools
- [x] No breaking changes (all new parameters are optional)