### PR TITLE
feat(organization): include external bank accounts by default

### DIFF
--- a/qonto_mcp/tools/organization/organization.py
+++ b/qonto_mcp/tools/organization/organization.py
@@ -5,17 +5,25 @@ from qonto_mcp import mcp
 
 
 @mcp.tool()
-def get_qonto_organization():
+def get_qonto_organization(include_external_accounts: bool = True):
     """
-    Retrieves organization and list of bank accounts from the Qonto API
+    Retrieves organization and list of bank accounts from the Qonto API.
+
+    By default, includes both Qonto accounts and external accounts connected
+    to the organization (e.g. accounts aggregated via open banking). Each
+    bank account in the response carries an `is_external_account` flag so
+    callers can filter as needed. Pass `include_external_accounts=False` to
+    restrict the response to Qonto-native accounts only.
 
     Example: get_qonto_organization()
+    Example: get_qonto_organization(include_external_accounts=False)
     """
     url = f"{qonto_mcp.thirdparty_host}/v2/organization"
+    params = {"include_external_accounts": str(include_external_accounts).lower()}
 
     try:
-        response = requests.get(url, headers=qonto_mcp.headers)
+        response = requests.get(url, headers=qonto_mcp.headers, params=params)
         response.raise_for_status()
         return response.json()
     except RequestException as e:
-        raise RuntimeError(f"Error fetching Qonto transactions {str(e)}")
+        raise RuntimeError(f"Error fetching Qonto organization {str(e)}")


### PR DESCRIPTION
## Summary

`get_qonto_organization` currently never returns externally-connected bank accounts (e.g. accounts aggregated via open banking from the Qonto dashboard), even though the Qonto API supports it. This PR forwards the documented `include_external_accounts` query parameter so the tool's output matches what users actually see in their Qonto app.

## Context & root cause

The [official `GET /v2/organization` spec](https://docs.qonto.com/api-reference/business-api/accounts-organizations/organizations/retrieve-the-authenticated-organization-and-list-bank-accounts) documents a query parameter:

> `include_external_accounts` — *By default includes only Qonto accounts. Set to 'true' if you also want to include your connected external account(s).*

The previous implementation in `qonto_mcp/tools/organization/organization.py` called the endpoint without any query params:

```python
url = f"{qonto_mcp.thirdparty_host}/v2/organization"
response = requests.get(url, headers=qonto_mcp.headers)
```

As a result, organization owners who had connected external accounts from the Qonto dashboard were missing those accounts (and their balances) entirely from MCP responses — a silent, confusing data gap with no error or hint that the filter even existed.

## Change

- Accept `include_external_accounts: bool = True` on the tool and forward it as a query param.
- Default to `True` so the tool's name and docstring (*"list of bank accounts"*) match its behavior. Each account in the response already carries an `is_external_account` flag, so downstream callers can filter locally if needed.
- Callers who explicitly want Qonto-native accounts only can still pass `include_external_accounts=False`, which produces the exact same payload as the previous implementation (strict opt-out for backward compatibility).
- Side fix: the error message had a copy-paste bug (`"Error fetching Qonto transactions"`) inside the organization tool — corrected to mention `organization`.

### Why `True` as the default?

- The tool is called `get_qonto_organization` and its docstring advertises *"organization and list of bank accounts"* — users legitimately expect the full list they see in-app.
- The prior default silently hid data the API key was allowed to see. That's the kind of behavior an LLM agent cannot reason about, because it has no way to know a hidden filter is being applied upstream.
- The response already distinguishes external vs. native via `is_external_account`, so richer defaults lose nothing in terms of filterability.
- If maintainers prefer to keep the Qonto API default (`False`) for strict mirroring of upstream, I'm happy to flip the default — the surface is identical either way and backward compat is preserved in both directions via the argument.

## Test plan

Verified end-to-end against the production Qonto API (`https://thirdparty.qonto.com`) using the stdio MCP transport from the Docker image built off this branch. Credentials and PII redacted below.

**1. Default call — previously missed external accounts, now returns them:**

```bash
echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_qonto_organization","arguments":{}}}' \
  | docker run --rm -i -e QONTO_API_KEY=<redacted> -e QONTO_ORGANIZATION_ID=<redacted> \
      -e QONTO_THIRDPARTY_HOST=https://thirdparty.qonto.com qonto-mcp-server:local
```

Returns 2 bank accounts (anonymized):

```json
{
  "bank_accounts": [
    { "name": "<External account>",  "iban": "FR76XXXXXXXXXXXXXXXXXXXXXXX", "is_external_account": true,  "balance": <redacted>, "status": "active" },
    { "name": "<Main account>",      "iban": "FR76XXXXXXXXXXXXXXXXXXXXXXX", "is_external_account": false, "balance": <redacted>, "status": "active" }
  ]
}
```

**2. Explicit `include_external_accounts=false` — backward-compat path returns only Qonto accounts:**

```bash
# arguments: {"include_external_accounts": false}
```

Returns 1 bank account:

```json
{
  "bank_accounts": [
    { "name": "<Main account>", "is_external_account": false, "balance": <redacted> }
  ]
}
```

**3. Regression check**

- `docker build .` succeeds (no new deps).
- MCP `initialize` handshake unchanged: server still advertises `tools.listChanged: false`.
- `tools/list` still exposes `get_qonto_organization`; the new optional argument is surfaced in the tool schema.

## Risk & scope

- **Scope**: 1 file, 1 function, ~12 added lines. No new dependencies.
- **Security**: no change to auth, headers, or credentials handling. The new query param is strictly a view-filter that the Qonto API already supports for the same scope (`organization.read`).
- **Breaking change risk**: the *shape* of each bank account object is unchanged — only the *number* of returned accounts may grow for users with external accounts connected. The `is_external_account` boolean already exists on the objects, so consumers that want to ignore externals can filter client-side, or pass `include_external_accounts=False` for strict equivalence with the old behavior.

## References

- [Qonto API — Retrieve authenticated organization](https://docs.qonto.com/api-reference/business-api/accounts-organizations/organizations/retrieve-the-authenticated-organization-and-list-bank-accounts)
- [Qonto support — How to connect my external accounts](https://support-fr.qonto.com/hc/en-us/articles/24231375285777-How-to-connect-my-external-accounts-to-my-Qonto-interface)