### PR TITLE
fix(ci): add linux/arm64 platform for Apple Silicon support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           push: true
           tags: qonto/qonto-mcp-server:latest
+          platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Questions or security concerns? Contact us at `security@qonto.com`.
 
 ### Option 1: Docker Installation (Recommended)
 
+> Supports both `linux/amd64` (Intel) and `linux/arm64` (Apple Silicon M1/M2/M3) natively.
+
 1. Pull the Docker image:
    ```bash
    docker pull qonto/qonto-mcp-server:latest


### PR DESCRIPTION
## Summary

- Adds `platforms: linux/amd64,linux/arm64` to the `docker/build-push-action` step in the CI workflow
- Without this field, the action only builds for the runner's native platform (`linux/amd64`), even though QEMU and Docker Buildx are already configured
- Updates the README to document that the image natively supports Apple Silicon (M1/M2/M3)

## Root cause

The workflow already has all the infrastructure needed for multi-platform builds:

```yaml
- name: Set up QEMU
  uses: docker/setup-qemu-action@v3
- name: Set up Docker Buildx
  uses: docker/setup-buildx-action@v3
```

But the `build-push-action` step was missing the `platforms` parameter, so it silently fell back to building only for `linux/amd64`.

## Verification

After merging, confirm both manifests are published:

```bash
docker buildx imagetools inspect qonto/qonto-mcp-server:latest
```

Expected output includes entries for both `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)