### PR TITLE
feat: add tool to mark transaction as not requiring attachment

### DIFF
--- a/qonto_mcp/tools/transactions/__init__.py
+++ b/qonto_mcp/tools/transactions/__init__.py
@@ -1,2 +1,2 @@
 from .transactions import get_qonto_transactions, get_qonto_transaction
-from .attachments import list_qonto_transaction_attachments
+from .attachments import list_qonto_transaction_attachments, mark_qonto_transaction_attachment_not_required

--- a/qonto_mcp/tools/transactions/attachments.py
+++ b/qonto_mcp/tools/transactions/attachments.py
@@ -40,3 +40,32 @@ def list_qonto_transaction_attachments(
         return response.json()
     except RequestException as e:
         raise RuntimeError(f"Failed to fetch transaction attachments {str(e)}")
+
+
+@mcp.tool()
+def mark_qonto_transaction_attachment_not_required(transaction_id: str):
+    """
+    Marks a transaction as not requiring an attachment in the Qonto API.
+
+    Use this when a transaction (e.g. a small expense, refund, or internal
+    transfer) does not need a receipt/invoice attached, to clear the
+    "attachment required" status.
+
+    Args:
+        transaction_id: UUID of the transaction
+
+    Example: mark_qonto_transaction_attachment_not_required(
+                transaction_id='aab86d8a-0d4c-4749-9a49-0ada88a9c423'
+             )
+    """
+    url = f"{qonto_mcp.thirdparty_host}/v2/transactions/{transaction_id}"
+    payload = {"attachment_required": False}
+
+    try:
+        response = requests.patch(url, headers=qonto_mcp.headers, json=payload)
+        response.raise_for_status()
+        return response.json()
+    except RequestException as e:
+        raise RuntimeError(
+            f"Failed to mark transaction as not requiring attachment: {str(e)}"
+        )


### PR DESCRIPTION
## Summary

Adds a new MCP tool `mark_qonto_transaction_attachment_not_required` that calls `PATCH /v2/transactions/{id}` with `{"attachment_required": false}` to clear the "attachment required" flag on a Qonto transaction.

This covers a gap where transactions that don't need a receipt/invoice (small expenses, refunds, internal transfers) currently have to be cleared via the Qonto web UI — there was no MCP equivalent.

## Changes

- `qonto_mcp/tools/transactions/attachments.py` — new `@mcp.tool()` function following the same pattern as the existing `list_qonto_transaction_attachments` (try/except on `RequestException`, raises `RuntimeError` with a descriptive message).
- `qonto_mcp/tools/transactions/__init__.py` — added the new function to the import list. Required so the `@mcp.tool()` decorator runs at server startup; tools in this repo are not auto-discovered (see [`server.py`](qonto_mcp/server.py) side-effect imports).

No new dependencies. README intentionally not updated — its tool list is high-level only.

## Test plan

- [ ] `python -c "from qonto_mcp.tools.transactions import mark_qonto_transaction_attachment_not_required"` succeeds
- [ ] MCP server boots without import errors
- [ ] Against a real transaction flagged `attachment_required: true`, calling the tool returns the transaction with `attachment_required: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)