### PR TITLE
feat(expense-management): add create-side tools for supplier invoices and multi-transfer requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ This MCP server provides the following tools for interacting with your Qonto acc
 - **Account Management**: Access account information and balances
 - **Transaction History**: Retrieve and analyze transaction data
 - **Business Operations**: Access business-related financial data
+- **Expense Management**: Create supplier invoices from receipts and submit multi-transfer requests for batch reimbursement
 
 ## Configuration
 

--- a/qonto_mcp/tools/invoices/invoices.py
+++ b/qonto_mcp/tools/invoices/invoices.py
@@ -1,3 +1,6 @@
+import mimetypes
+import os
+import uuid
 import requests
 from datetime import datetime
 from typing import Dict, Optional
@@ -5,6 +8,9 @@ from requests.exceptions import RequestException
 
 import qonto_mcp
 from qonto_mcp import mcp
+
+
+_SUPPLIER_INVOICE_MIME_TYPES = {"image/jpeg", "image/png", "application/pdf"}
 
 
 @mcp.tool()
@@ -124,3 +130,71 @@ def get_credit_notes(
         return response.json()
     except RequestException as e:
         raise RuntimeError(f"Failed to fetch credit notes {str(e)}")
+
+
+@mcp.tool()
+def create_qonto_supplier_invoice(
+    file_path: Optional[str] = None,
+    attachment_id: Optional[str] = None,
+) -> Dict:
+    """
+    Create a supplier invoice in Qonto from a local file or an existing attachment.
+
+    Submits one supplier invoice (vendor bill) to Qonto's bulk endpoint. Qonto
+    will OCR the document and route it through the standard supplier-invoice
+    approval workflow. Use this to record paid expenses, vendor receipts, or
+    pay-by-invoice items.
+
+    Provide exactly one of:
+        - file_path: a local PDF/PNG/JPEG to upload, OR
+        - attachment_id: the UUID of an attachment already known to Qonto
+          (e.g. one returned by list_qonto_transaction_attachments).
+
+    The endpoint always returns HTTP 200 — even when an individual item fails.
+    Inspect the `errors` array of the returned object to confirm success.
+
+    Args:
+        file_path: Absolute or relative path to a PDF/JPEG/PNG file on disk.
+        attachment_id: UUID of an existing Qonto attachment to convert into
+            a supplier invoice.
+
+    Example: create_qonto_supplier_invoice(file_path="/Users/alice/bills/acme.pdf")
+    """
+    if (file_path is None) == (attachment_id is None):
+        raise ValueError(
+            "Provide exactly one of file_path or attachment_id (not both, not neither)."
+        )
+
+    url = f"{qonto_mcp.thirdparty_host}/v2/supplier_invoices/bulk"
+    idempotency_key = str(uuid.uuid4())
+
+    upload_headers = {**qonto_mcp.headers}
+    upload_headers.pop("Accept", None)
+
+    try:
+        if file_path is not None:
+            if not os.path.isfile(file_path):
+                raise ValueError(f"File not found: {file_path}")
+            mime_type, _ = mimetypes.guess_type(file_path)
+            if mime_type not in _SUPPLIER_INVOICE_MIME_TYPES:
+                raise ValueError(
+                    f"Unsupported file type '{mime_type}'. Must be PDF, JPEG, or PNG."
+                )
+            filename = os.path.basename(file_path)
+            with open(file_path, "rb") as f:
+                files = {
+                    "supplier_invoices[][file]": (filename, f, mime_type),
+                    "supplier_invoices[][idempotency_key]": (None, idempotency_key),
+                }
+                response = requests.post(url, headers=upload_headers, files=files)
+        else:
+            files = {
+                "supplier_invoices[][attachment_id]": (None, attachment_id),
+                "supplier_invoices[][idempotency_key]": (None, idempotency_key),
+            }
+            response = requests.post(url, headers=upload_headers, files=files)
+
+        response.raise_for_status()
+        return response.json()
+    except RequestException as e:
+        raise RuntimeError(f"Failed to create supplier invoice: {str(e)}")

--- a/qonto_mcp/tools/requests/requests.py
+++ b/qonto_mcp/tools/requests/requests.py
@@ -1,10 +1,14 @@
+import uuid
 import requests
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Any, Dict, List, Optional
 from requests.exceptions import RequestException
 
 import qonto_mcp
 from qonto_mcp import mcp
+
+
+_REQUIRED_TRANSFER_FIELDS = ("amount", "credit_iban", "credit_account_name", "reference")
 
 
 @mcp.tool()
@@ -66,3 +70,90 @@ def get_request(request_id: str) -> Dict:
         return response.json()
     except RequestException as e:
         raise RuntimeError(f"Error fetching request: {str(e)}")
+
+
+@mcp.tool()
+def create_qonto_multi_transfer_request(
+    note: str,
+    transfers: List[Dict[str, Any]],
+    scheduled_date: Optional[str] = None,
+    debit_iban: Optional[str] = None,
+) -> Dict:
+    """
+    Create a multi-transfer request in Qonto (the canonical "expense report" /
+    batch reimbursement flow under Expense Management → Requests).
+
+    Submits a batch of one or more transfers in a single approval request. Use
+    this to reimburse an employee for several receipts at once, or to pay a
+    list of suppliers in one approval cycle. All amounts are in EUR.
+
+    Args:
+        note: Free-text note for the request, shown to the approver (≤140 chars).
+        transfers: List of 1–400 transfer items. Each item is a dict with:
+            - amount (str, required): decimal with 2 digits, e.g. "12.34"
+            - credit_iban (str, required): IBAN of the recipient (ISO 13616)
+            - credit_account_name (str, required): recipient name (≤140 chars)
+            - reference (str, required): payment reference (≤140 chars)
+            - attachment_ids (List[str], optional): UUIDs of receipts/invoices
+              already known to Qonto (e.g. from list_qonto_transaction_attachments)
+        scheduled_date: Optional execution date (YYYY-MM-DD); defaults to the
+            current/next banking day.
+        debit_iban: Optional IBAN of the Qonto account to debit; defaults to
+            the organization's main account.
+
+    Example: create_qonto_multi_transfer_request(
+                note="March travel expenses",
+                transfers=[
+                    {
+                        "amount": "42.00",
+                        "credit_iban": "FR7630006000011234567890189",
+                        "credit_account_name": "Alice Dupont",
+                        "reference": "Taxi 2026-03-12",
+                    }
+                ],
+             )
+    """
+    if len(note) > 140:
+        raise ValueError("note must be 140 characters or fewer.")
+    if not 1 <= len(transfers) <= 400:
+        raise ValueError("transfers must contain between 1 and 400 items.")
+
+    payload_transfers: List[Dict[str, Any]] = []
+    for index, transfer in enumerate(transfers):
+        missing = [field for field in _REQUIRED_TRANSFER_FIELDS if not transfer.get(field)]
+        if missing:
+            raise ValueError(
+                f"transfers[{index}] is missing required field(s): {', '.join(missing)}"
+            )
+        if len(transfer["credit_account_name"]) > 140:
+            raise ValueError(f"transfers[{index}].credit_account_name must be ≤140 chars.")
+        if len(transfer["reference"]) > 140:
+            raise ValueError(f"transfers[{index}].reference must be ≤140 chars.")
+
+        item: Dict[str, Any] = {
+            "amount": transfer["amount"],
+            "currency": "EUR",
+            "credit_iban": transfer["credit_iban"],
+            "credit_account_name": transfer["credit_account_name"],
+            "credit_account_currency": "EUR",
+            "reference": transfer["reference"],
+        }
+        if transfer.get("attachment_ids"):
+            item["attachment_ids"] = transfer["attachment_ids"]
+        payload_transfers.append(item)
+
+    body: Dict[str, Any] = {"note": note, "transfers": payload_transfers}
+    if scheduled_date is not None:
+        body["scheduled_date"] = scheduled_date
+    if debit_iban is not None:
+        body["debit_iban"] = debit_iban
+
+    url = f"{qonto_mcp.thirdparty_host}/v2/requests/multi_transfers"
+    headers = {**qonto_mcp.headers, "X-Qonto-Idempotency-Key": str(uuid.uuid4())}
+
+    try:
+        response = requests.post(url, headers=headers, json={"request_multi_transfer": body})
+        response.raise_for_status()
+        return response.json()
+    except RequestException as e:
+        raise RuntimeError(f"Failed to create multi-transfer request: {str(e)}")

--- a/qonto_mcp/tools/transactions/__init__.py
+++ b/qonto_mcp/tools/transactions/__init__.py
@@ -1,2 +1,2 @@
 from .transactions import get_qonto_transactions, get_qonto_transaction
-from .attachments import list_qonto_transaction_attachments
+from .attachments import list_qonto_transaction_attachments, upload_transaction_attachment

--- a/qonto_mcp/tools/transactions/__init__.py
+++ b/qonto_mcp/tools/transactions/__init__.py
@@ -1,2 +1,2 @@
 from .transactions import get_qonto_transactions, get_qonto_transaction
-from .attachments import list_qonto_transaction_attachments
+from .attachments import list_qonto_transaction_attachments, mark_qonto_transaction_attachment_not_required

--- a/qonto_mcp/tools/transactions/attachments.py
+++ b/qonto_mcp/tools/transactions/attachments.py
@@ -40,3 +40,32 @@ def list_qonto_transaction_attachments(
         return response.json()
     except RequestException as e:
         raise RuntimeError(f"Failed to fetch transaction attachments {str(e)}")
+
+
+@mcp.tool()
+def mark_qonto_transaction_attachment_not_required(transaction_id: str):
+    """
+    Marks a transaction as not requiring an attachment in the Qonto API.
+
+    Use this when a transaction (e.g. a small expense, refund, or internal
+    transfer) does not need a receipt/invoice attached, to clear the
+    "attachment required" status.
+
+    Args:
+        transaction_id: UUID of the transaction
+
+    Example: mark_qonto_transaction_attachment_not_required(
+                transaction_id='aab86d8a-0d4c-4749-9a49-0ada88a9c423'
+             )
+    """
+    url = f"{qonto_mcp.thirdparty_host}/v2/transactions/{transaction_id}"
+    payload = {"attachment_required": False}
+
+    try:
+        response = requests.patch(url, headers=qonto_mcp.headers, json=payload)
+        response.raise_for_status()
+        return response.json()
+    except RequestException as e:
+        raise RuntimeError(
+            f"Failed to mark transaction as not requiring attachment: {str(e)}"
+        )

--- a/qonto_mcp/tools/transactions/attachments.py
+++ b/qonto_mcp/tools/transactions/attachments.py
@@ -1,8 +1,13 @@
+import os
+import uuid
+import mimetypes
 from typing import Optional
 import requests
 from requests.exceptions import RequestException
 import qonto_mcp
 from qonto_mcp import mcp
+
+ALLOWED_MIME_TYPES = {"image/jpeg", "image/png", "application/pdf"}
 
 
 @mcp.tool()
@@ -40,3 +45,58 @@ def list_qonto_transaction_attachments(
         return response.json()
     except RequestException as e:
         raise RuntimeError(f"Failed to fetch transaction attachments {str(e)}")
+
+
+@mcp.tool()
+def upload_transaction_attachment(transaction_id: str, file_path: str):
+    """
+    Uploads a file from the local filesystem and attaches it to a Qonto transaction.
+
+    Accepted file formats: JPEG, PNG, PDF.
+    The attachment is processed asynchronously — it may not appear immediately when
+    listing attachments.
+
+    Args:
+        transaction_id: UUID of the transaction to attach the file to
+        file_path: Absolute or relative path to the file on disk (JPEG/PNG/PDF)
+
+    Example: upload_transaction_attachment(
+                transaction_id='aab86d8a-0d4c-4749-9a49-0ada88a9c423',
+                file_path='/Users/alice/receipts/lunch.pdf'
+             )
+    """
+    # Validate file exists
+    if not os.path.isfile(file_path):
+        raise ValueError(f"File not found: {file_path}")
+
+    # Detect and validate MIME type
+    mime_type, _ = mimetypes.guess_type(file_path)
+    if mime_type not in ALLOWED_MIME_TYPES:
+        raise ValueError(
+            f"Unsupported file type '{mime_type}'. Must be one of: JPEG, PNG, PDF."
+        )
+
+    url = f"{qonto_mcp.thirdparty_host}/v2/transactions/{transaction_id}/attachments"
+    filename = os.path.basename(file_path)
+
+    # Build upload headers — do NOT set Content-Type manually;
+    # requests sets it with the correct multipart boundary automatically.
+    # Add the required idempotency key on top of the global auth headers.
+    upload_headers = {**qonto_mcp.headers, "X-Qonto-Idempotency-Key": str(uuid.uuid4())}
+    upload_headers.pop("Accept", None)
+
+    try:
+        with open(file_path, "rb") as f:
+            response = requests.post(
+                url,
+                headers=upload_headers,
+                files={"file": (filename, f, mime_type)},
+            )
+        response.raise_for_status()
+        # Response may be empty (async processing) or contain attachment id
+        try:
+            return response.json()
+        except Exception:
+            return {"status": "accepted", "message": "Attachment is being processed."}
+    except RequestException as e:
+        raise RuntimeError(f"Failed to upload attachment: {str(e)}")


### PR DESCRIPTION
## Summary

Adds two new MCP tools that together provide full create-side coverage of Qonto's expense-management workflows. Previously the server only exposed the read counterparts (`get_requests`, `get_supplier_invoices`).

Qonto's API has no literal `expense_report` resource. Under **Expense Management**, the two endpoints that map to the "create an expense report" intent are:

- `POST /v2/requests/multi_transfers` — the canonical "submit a batch of expenses for approval / reimburse me for these receipts" flow.
- `POST /v2/supplier_invoices/bulk` — upload vendor bills (PDF/PNG/JPEG) which Qonto OCRs and routes through approval.

This PR wraps both.

## What changed

- **`create_qonto_multi_transfer_request`** in `qonto_mcp/tools/requests/requests.py`
  - JSON body wrapped under `request_multi_transfer`, with a per-call `X-Qonto-Idempotency-Key` header (same pattern as `upload_transaction_attachment`).
  - Local validation before the HTTP call: `note ≤ 140 chars`, `1 ≤ len(transfers) ≤ 400`, each transfer must have `amount`/`credit_iban`/`credit_account_name`/`reference`, and `credit_account_name`/`reference` ≤ 140 chars.
  - `currency` and `credit_account_currency` are filled in as `"EUR"` automatically (the API rejects anything else).

- **`create_qonto_supplier_invoice`** in `qonto_mcp/tools/invoices/invoices.py`
  - Accepts **either** `file_path` (uploads PDF/PNG/JPEG) **or** `attachment_id` (references an existing attachment, e.g. one returned by `list_qonto_transaction_attachments`) — exactly one of the two.
  - Sends the multipart array-bracket field-name shape Qonto's `cURL` example uses (`supplier_invoices[][file]`, `supplier_invoices[][idempotency_key]`).
  - Returns the bulk endpoint's response verbatim — the endpoint always returns 200 and surfaces per-item failures in the body's `errors[]` array, so callers (the LLM) can inspect that.

- **`README.md`** — added an "Expense Management" line under "Available Tools" matching the existing high-level-category style.

## Reviewer notes

- No new directories or files. Both tools live next to their existing read-side siblings, so module imports in `qonto_mcp/server.py` did not need to change.
- Followed the existing per-tool `requests.post(...)` pattern — no HTTP-client abstraction was introduced (out of scope for two new tools).
- For the supplier-invoice `attachment_id` variant, the body is still sent as `multipart/form-data` (using `(None, value)` tuples in the `files=` kwarg) because the Qonto endpoint expects multipart, not URL-encoded form data.

## Test plan

The repo has no test suite, so verification is manual against the Qonto sandbox.

- [x] `python -m py_compile` passes for both modified modules.
- [x] Both tools import cleanly under FastMCP and `@mcp.tool()` accepts the signatures.
- [x] All six local validation guards fire as expected without making any HTTP calls (empty `transfers`, missing per-transfer field, neither/both file_path+attachment_id, missing file).
- [ ] Sandbox: `create_qonto_multi_transfer_request` with `note="Q1 expenses"` and one small EUR transfer returns a `request_multi_transfer.id` with `status: "pending"`.
- [ ] Sandbox: `create_qonto_supplier_invoice(file_path="…sample.pdf")` returns a body with one entry in `supplier_invoices[]` and an empty `errors[]`; the invoice then appears in `get_supplier_invoices`.
- [ ] Sandbox: `create_qonto_supplier_invoice(attachment_id="…")` using an attachment id from `list_qonto_transaction_attachments` succeeds without re-uploading.
- [ ] Sandbox: per-item error surfacing — uploading an unsupported file type (bypassing the local MIME guard) yields a 200 with an entry in `errors[]`, returned verbatim rather than raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)