### PR TITLE
fix(invoices): send `page` as the pagination query param, not `current_page`

### DIFF
--- a/qonto_mcp/tools/invoices/invoices.py
+++ b/qonto_mcp/tools/invoices/invoices.py
@@ -30,7 +30,7 @@ def get_client_invoices(
     url = f"{qonto_mcp.thirdparty_host}/v2/client_invoices"
     params = {}
     if current_page is not None:
-        params["current_page"] = current_page
+        params["page"] = current_page
     if per_page is not None:
         params["per_page"] = per_page
     if status is not None:
@@ -71,7 +71,7 @@ def get_supplier_invoices(
     url = f"{qonto_mcp.thirdparty_host}/v2/supplier_invoices"
     params = {}
     if current_page is not None:
-        params["current_page"] = current_page
+        params["page"] = current_page
     if per_page is not None:
         params["per_page"] = per_page
     if status is not None:
@@ -110,7 +110,7 @@ def get_credit_notes(
     url = f"{qonto_mcp.thirdparty_host}/v2/credit_notes"
     params = {}
     if current_page is not None:
-        params["current_page"] = current_page
+        params["page"] = current_page
     if per_page is not None:
         params["per_page"] = per_page
     if updated_at_from is not None:


### PR DESCRIPTION
## Problem

Fixes #14.

`get_supplier_invoices` (and the other two invoice tools) ignore the `current_page` argument — every call returns page 1, so with 380 supplier invoices only the 50 most recent are reachable.

## Root cause

The invoice tools send `current_page` as the query parameter:

```python
if current_page is not None:
    params["current_page"] = current_page
```

But the Qonto API paginates on `page`. `current_page` is the field the API returns in the response body, not one it reads from the request, so the parameter is silently ignored and pagination pins to page 1.

Every other paginated tool in this repo already sends `page` — `labels`, `beneficiaries`, `memberships`, `external_transfers`, `transactions/attachments`. The three invoice tools (`get_client_invoices`, `get_supplier_invoices`, `get_credit_notes`) were the only ones passing `current_page`, so they share the same defect and are all fixed here.

## Fix

Map the argument to `page` on the wire, matching the rest of the repo:

```python
params["page"] = current_page
```

The MCP argument name stays `current_page`, so the tool signatures are unchanged — a client that calls `get_supplier_invoices(current_page=2)` keeps working, it just now reaches page 2.

If you'd rather rename the argument to `page` for full consistency with the other tools, that's a public-surface call I'll leave to you; this PR keeps it non-breaking.

## Verification

Static: the fix aligns the invoice tools with the five other paginated tools in the repo that work. I don't have live API credentials to run an end-to-end paginated call — happy to adjust if your integration tests show the endpoint expects a different shape.
