### PR TITLE
fix(ci): add linux/arm64 platform for Apple Silicon support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           push: true
           tags: qonto/qonto-mcp-server:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Fixes #5

The workflow already configures QEMU and Buildx for multi-arch, but the `build-push-action` step was missing the `platforms` parameter. Without it the image is built only for the runner architecture (linux/amd64), so `docker pull` on Apple Silicon fails with no matching manifest for linux/arm64/v8.

This change adds `platforms: linux/amd64,linux/arm64` to produce a multi-arch manifest, as suggested in the issue.

Verification after merge:
```bash
docker buildx imagetools inspect qonto/qonto-mcp-server:latest
```
should list both `linux/amd64` and `linux/arm64`.

Related: #2, #10 (previous attempts closed without merge)