### PR TITLE
chore(tests): bootstrap a pytest suite, and pin mcp to v1 so the package imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ The server supports both `stdio` and `streamable-http` transport protocols. Use 
 
 Contributions are welcome! Please feel free to submit issues and enhancement requests.
 
+### Running the tests
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+The suite runs offline: `requests.get` is replaced by a fixture, so no test reaches the Qonto
+API or needs credentials. It also runs on every pull request, on Python 3.10 and 3.13.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mcp>=1.0.0
+mcp>=1.0.0,<2
 requests>=2.25.0
 python-dotenv>=0.19.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,64 @@
+import pytest
+
+import qonto_mcp
+
+ENV = {
+    "QONTO_THIRDPARTY_HOST": "https://thirdparty.example.com",
+    "QONTO_API_KEY": "test-api-key",
+    "QONTO_ORGANIZATION_ID": "test-org",
+}
+
+
+@pytest.fixture
+def qonto_env(monkeypatch):
+    """Set the environment variables the server requires, and nothing else."""
+    for name, value in ENV.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.delenv("QONTO_STAGING_TOKEN", raising=False)
+    return dict(ENV)
+
+
+@pytest.fixture
+def configured(qonto_env):
+    """Configure the module globals the tools read at call time."""
+    qonto_mcp.setup_qonto_config()
+    return qonto_mcp
+
+
+class FakeResponse:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def capture_get(monkeypatch):
+    """Replace requests.get, record the call, and return a canned response.
+
+    Use `set_payload` for the happy path and `set_error` to make the request
+    raise, so a test never reaches the network.
+    """
+
+    calls = []
+
+    def fake_get(url, headers=None, params=None, **kwargs):
+        calls.append({"url": url, "headers": headers, "params": params})
+        if fake_get.error is not None:
+            raise fake_get.error
+        return FakeResponse(fake_get.payload)
+
+    fake_get.calls = calls
+    fake_get.payload = {}
+    fake_get.error = None
+    fake_get.set_payload = lambda payload: setattr(fake_get, "payload", payload)
+    fake_get.set_error = lambda error: setattr(fake_get, "error", error)
+
+    monkeypatch.setattr("requests.get", fake_get)
+    return fake_get

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+import pytest
+
+import qonto_mcp
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["QONTO_THIRDPARTY_HOST", "QONTO_API_KEY", "QONTO_ORGANIZATION_ID"],
+)
+def test_setup_requires_every_mandatory_variable(qonto_env, monkeypatch, missing):
+    monkeypatch.delenv(missing, raising=False)
+
+    with pytest.raises(ValueError, match=missing):
+        qonto_mcp.setup_qonto_config()
+
+
+def test_setup_builds_the_authorization_header(configured):
+    assert configured.headers["Accept"] == "application/json"
+    assert configured.headers["Authorization"] == "test-org:test-api-key"
+    assert configured.thirdparty_host == "https://thirdparty.example.com"
+
+
+def test_staging_token_is_optional(configured):
+    assert "X-Qonto-Staging-Token" not in configured.headers
+
+
+def test_staging_token_is_forwarded_when_set(qonto_env, monkeypatch):
+    monkeypatch.setenv("QONTO_STAGING_TOKEN", "staging-token")
+
+    qonto_mcp.setup_qonto_config()
+
+    assert qonto_mcp.headers["X-Qonto-Staging-Token"] == "staging-token"

--- a/tests/test_invoices.py
+++ b/tests/test_invoices.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+import pytest
+from requests.exceptions import RequestException
+
+from qonto_mcp.tools.invoices.invoices import get_client_invoices
+
+
+def test_only_the_provided_filters_are_sent(configured, capture_get):
+    get_client_invoices(per_page=10, status="paid")
+
+    params = capture_get.calls[0]["params"]
+    assert params["per_page"] == 10
+    assert params["status"] == "paid"
+    assert "updated_at_from" not in params
+    assert "updated_at_to" not in params
+
+
+def test_dates_are_sent_in_iso_format(configured, capture_get):
+    get_client_invoices(updated_at_from=datetime(2026, 1, 2, 3, 4, 5))
+
+    assert capture_get.calls[0]["params"]["updated_at_from"] == "2026-01-02T03:04:05"
+
+
+def test_request_failures_are_raised_as_runtime_errors(configured, capture_get):
+    capture_get.set_error(RequestException("connection reset"))
+
+    with pytest.raises(RuntimeError, match="Failed to fetch client invoices"):
+        get_client_invoices()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,38 @@
+from qonto_mcp.tools.transactions.transactions import (
+    get_qonto_transaction,
+    get_qonto_transactions,
+)
+
+
+def test_transactions_are_scoped_to_a_bank_account(configured, capture_get):
+    capture_get.set_payload({"transactions": []})
+
+    result = get_qonto_transactions(bank_account_id="account-1")
+
+    call = capture_get.calls[0]
+    assert call["url"] == "https://thirdparty.example.com/v2/transactions"
+    assert call["params"] == {"bank_account_id": "account-1"}
+    assert call["headers"]["Authorization"] == "test-org:test-api-key"
+    assert result == {"transactions": []}
+
+
+def test_includes_are_sent_as_a_repeated_parameter(configured, capture_get):
+    get_qonto_transaction(transaction_id="tx-1", includes=["labels", "attachments"])
+
+    call = capture_get.calls[0]
+    assert call["url"] == "https://thirdparty.example.com/v2/transactions/tx-1"
+    assert call["params"] == {"includes[]": ["labels", "attachments"]}
+
+
+def test_transaction_without_includes_sends_no_parameters(configured, capture_get):
+    get_qonto_transaction(transaction_id="tx-1")
+
+    assert capture_get.calls[0]["params"] == {}
+
+
+def test_transaction_errors_are_returned_as_a_message(configured, capture_get):
+    capture_get.set_error(RuntimeError("boom"))
+
+    result = get_qonto_transactions(bank_account_id="account-1")
+
+    assert result == "Error fetching Qonto transactions: boom"


### PR DESCRIPTION
## What

Adds a pytest suite to the repository, runs it on every pull request, and pins `mcp` to the v1 line so the package imports again on a fresh install.

## Why

The repository currently has no tests. The two open community PRs (#17, #18) change request parameters and build configuration with nothing to verify them against, and there is no way to tell whether a change breaks a tool other than running the server by hand against a live Qonto account.

While writing the suite I found that a fresh install is broken today. `requirements.txt` asks for `mcp>=1.0.0`, and mcp 2.0 renamed `FastMCP` to `MCPServer`, so `qonto_mcp/__init__.py` fails at import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x, where
FastMCP was renamed to MCPServer ... or pin 'mcp<2' to keep running v1 code.
```

The `Dockerfile` installs from the same unpinned file, so the published image has the same problem on any rebuild. The first commit pins `mcp>=1.0.0,<2`; the suite then guards against that class of breakage, since every test imports the package.

## How

- `requirements-dev.txt` pulls in the runtime requirements plus pytest, nothing else
- `pytest.ini` points pytest at `tests/`
- `tests/conftest.py` holds three fixtures: the environment variables the server needs, a configured module, and a `requests.get` replacement that records the call and returns a canned response. **The suite is entirely offline and needs no credentials.**
- 13 tests over the three areas that are easiest to break silently:
  - `setup_qonto_config`: each missing environment variable raises, the `Authorization` header is `organization_id:api_key`, and the staging token header appears only when the variable is set
  - transactions: the URL and parameters sent for a bank account, `includes` serialised as the repeated `includes[]` parameter, and the "Error fetching..." string returned on failure
  - invoices: only the filters actually passed are sent, datetimes are serialised as ISO 8601, and a `RequestException` is re-raised as a `RuntimeError`
- `.github/workflows/tests.yml` runs `pytest` on pushes to `main` and on pull requests, against Python 3.10 and 3.13 (the range the README advertises)
- README gains a short "Running the tests" section under Contributing

The tests assert current behaviour on `main` only. In particular they say nothing about the pagination parameter naming discussed in #17, so the two do not conflict in either merge order.

## Testing

`pytest` locally on Python 3.14 and inside the CI matrix: 13 passed. Each test was also checked against a deliberately broken source: changing `includes[]` to `includes` fails exactly one test, and reverting the `mcp` pin fails the whole suite at collection.

## Note

I see the README says this local server is no longer actively maintained in favour of the hosted one at mcp.qonto.com. If you would rather not carry a test suite here, say the word and I will close this. It seemed worth offering because the repository still ships a Docker image that a rebuild would break today.
